### PR TITLE
Make warnings and deprecation info go away on PHP>8.3

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -251,6 +251,19 @@ if (isset($md5) && $md5 != $session[3] && $update_sucess === TRUE) {
   $response = curl_exec($ch);
   if ($response === FALSE) die(curl_error($ch));
   $responseData = json_decode($response, TRUE);
+  if (isset($responseData['data']['attributes'])) {
+    $attr = $responseData['data']['attributes'];
+    
+    $s = $attr['chargeMode'] ?? 'unknown';
+    
+    // Fix for line 270: Ensure the date string isn't null
+    $rawDate = $attr['timestamp'] ?? null; 
+    $date = $rawDate ? date_create_from_format('Y-m-d', $rawDate) : null;
+} else {
+    // Handle the error state (API down, no data, etc.)
+    $s = 'error';
+    $date = null;
+}
   $s = $responseData['data']['attributes']['chargeMode'];
   if (empty($s)) $session[24] = 'n/a';
   else $session[24] = $s;


### PR DESCRIPTION
Make warnings and deprecation info go away on PHP>8.3

Warning: Undefined array key "data" in ./src/index.php on line 254
Warning: Trying to access array offset on null in ./src/index.php on line 254
[..] several other rows, complaining about the same thing
Deprecated: date_create_from_format(): Passing null to parameter #2 ($datetime) of type string is deprecated in ./src/index.php on line 270